### PR TITLE
Update for python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,7 @@
 build
+
+# noahp added
+/.tox/
+/.eggs/
+/*.egg-info/
+/dist/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,31 @@
+FROM ubuntu:focal-20200319
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && apt-get install -y \
+    arj \
+    cpio \
+    gzip \
+    lhasa \
+    lrzip \
+    lzip \
+    p7zip-full \
+    python-pip-whl \
+    python2.7 \
+    python3-pip \
+    python3.8 \
+    unrar \
+    wget \
+    zip
+
+RUN pip3 install tox==3.14.6
+
+# create a user inside the container. if you specify your UID when building the
+# image, you can mount directories into the container with read-write access:
+# docker build -t "dtrx" -f Dockerfile --build-arg UID=$(id -u) .
+ARG UID=1010
+ARG UNAME=builder
+RUN useradd --uid ${UID} --create-home --user-group ${UNAME} && \
+    echo "${UNAME}:${UNAME}" | chpasswd && adduser ${UNAME} sudo
+
+USER ${UNAME}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-====
-dtrx
-====
+# dtrx
 
-----------------------------------
-cleanly extract many archive types
-----------------------------------
+> cleanly extract many archive types
 
 :Author: Brett Smith <brettcsmith@brettcsmith.org>
 :Date:   2011-11-19
@@ -14,30 +10,34 @@ cleanly extract many archive types
   send comments, bug reports, patches, and so on.  You can find the latest
   version of dtrx on its home page at
   <http://www.brettcsmith.org/2007/dtrx/>.
-  
+
   dtrx is free software; you can redistribute it and/or modify it under the
   terms of the GNU General Public License as published by the Free Software
   Foundation; either version 3 of the License, or (at your option) any
   later version.
-  
+
   This program is distributed in the hope that it will be useful, but
   WITHOUT ANY WARRANTY; without even the implied warranty of
   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
   Public License for more details.
-  
+
   You should have received a copy of the GNU General Public License along
   with this program; if not, see <http://www.gnu.org/licenses/>.
 
 :Version: 7.1
 :Manual section: 1
 
-SYNOPSIS
-========
+## SYNOPSIS
 
-dtrx [OPTIONS] ARCHIVE [ARCHIVE ...]
+`dtrx [OPTIONS] ARCHIVE [ARCHIVE ...]`
 
-DESCRIPTION
-===========
+## INSTALLATION
+
+Copy [scripts/dtrx](scripts/dtrx) to a directory on PATH.
+
+TODO- deploy to pypi to make it pip-installable!
+
+## DESCRIPTION
 
 dtrx extracts archives in a number of different formats; it currently
 supports tar, zip (including self-extracting .exe files), cpio, rpm, deb,
@@ -60,11 +60,11 @@ You may specify URLs as arguments as well.  If you do, dtrx will use `wget
 downloads.  This may fail if you already have a file in the current
 directory with the same name as the file you're trying to download.
 
-OPTIONS
-=======
+## OPTIONS
 
 dtrx supports a number of options to mandate specific behavior:
 
+```manpage
 -r, --recursive
    With this option, dtrx will search inside the archives you specify to see
    if any of the contents are themselves archives, and extract those as
@@ -124,3 +124,21 @@ dtrx supports a number of options to mandate specific behavior:
 
 --version
    Display dtrx's version, copyright, and license information.
+```
+
+## TESTING
+
+[tests/compare.py](tests/compare.py) is a script that loads
+[tests/tests.yml](tests/tests.yml) and runs some tests on various archive
+formats. To handle all the formats, a variety of tools need to be installed on
+the test system. A Dockerfile is provided for convenience to test without
+modifying the host system. To use the Dockerfile to run the tests, you might do:
+
+```shell
+# build the image
+docker build -t "dtrx" -f Dockerfile --build-arg UID=$(id -u) .
+
+# run tox in the container. note tox is being run serially (no -p auto), in case
+# the working dir gets abused by the test script
+docker run -v"$(pwd):/mnt/workspace" -t dtrx bash -c "cd /mnt/workspace && tox -s true"
+```

--- a/scripts/dtrx
+++ b/scripts/dtrx
@@ -21,8 +21,10 @@
 
 # Python 2.3 string methods: 'rfind', 'rindex', 'rjust', 'rstrip'
 
+from __future__ import absolute_import, print_function
 import errno
 import fcntl
+from functools import cmp_to_key, total_ordering
 import logging
 import mimetypes
 import optparse
@@ -39,7 +41,19 @@ import tempfile
 import termios
 import textwrap
 import traceback
-import urlparse
+
+# Python 3 compatibility hacks commence
+try:
+    import urlparse
+except ModuleNotFoundError:
+    import urllib.parse as urlparse
+
+if sys.version_info[0] >= 3:
+    get_input = input
+    def cmp(a, b):
+        return (a > b) - (a < b)
+else:
+    get_input = raw_input
 
 try:
     set
@@ -101,7 +115,7 @@ class FilenameChecker(object):
     def is_free(self, filename):
         try:
             result = self.free_func(filename, *self.free_args)
-        except OSError, error:
+        except OSError as error:
             if error.errno == errno.EEXIST:
                 return False
             raise
@@ -149,7 +163,7 @@ class BaseExtractor(object):
     name_checker = DirectoryChecker
 
     def __init__(self, filename, encoding):
-        if encoding and (not self.decoders.has_key(encoding)):
+        if encoding and (encoding not in self.decoders):
             raise ValueError("unrecognized encoding %s" % (encoding,))
         self.filename = os.path.realpath(filename)
         self.encoding = encoding
@@ -163,7 +177,7 @@ class BaseExtractor(object):
         self.exit_codes = []
         try:
             self.archive = open(filename, 'r')
-        except (IOError, OSError), error:
+        except (IOError, OSError) as error:
             raise ExtractorError("could not open %s: %s" %
                                  (filename, error.strerror))
         if encoding:
@@ -178,7 +192,7 @@ class BaseExtractor(object):
             processes.append(subprocess.Popen(command, stdin=stdin,
                                               stdout=stdout,
                                               stderr=self.stderr))
-        except OSError, error:
+        except OSError as error:
             if error.errno == errno.ENOENT:
                 raise ExtractorUnusable("could not run %s" % (command[0],))
             raise
@@ -253,12 +267,12 @@ class BaseExtractor(object):
         # 2. Then remove any commonly known extension that remains.
         # 3. If neither of those did anything, remove anything that looks
         #    like it's almost certainly an extension (less than 5 chars).
-        if mimetypes.encodings_map.has_key(extension):
+        if extension in mimetypes.encodings_map:
             pieces.pop()
             extension = '.' + pieces[-1]
-        if (mimetypes.types_map.has_key(extension) or
-            mimetypes.common_types.has_key(extension) or
-            mimetypes.suffix_map.has_key(extension)):
+        if (extension in mimetypes.types_map or
+            extension in mimetypes.common_types or
+            extension in mimetypes.suffix_map):
             pieces.pop()
         if ((orig_len == len(pieces)) and
             (orig_len > 1) and (len(pieces[-1]) < 5)):
@@ -290,7 +304,7 @@ class BaseExtractor(object):
             raise ExtractorError("%s error: '%s' returned status code %s" %
                                  (self.pipes[error_index][1], command,
                                   error_code))
-        
+
     def extract_archive(self):
         self.pipe(self.extract_pipe)
         self.run_pipes()
@@ -298,7 +312,7 @@ class BaseExtractor(object):
     def extract(self):
         try:
             self.target = tempfile.mkdtemp(prefix='.dtrx-', dir='.')
-        except (OSError, IOError), error:
+        except (OSError, IOError) as error:
             raise ExtractorError("cannot extract here: %s" % (error.strerror,))
         old_path = os.path.realpath(os.curdir)
         os.chdir(self.target)
@@ -326,7 +340,7 @@ class BaseExtractor(object):
             stdin = processes[-1].stdout
         get_output_line = processes[-1].stdout.readline
         while True:
-            line = get_output_line()
+            line = get_output_line().decode("ascii", errors="ignore")
             if not line:
                 break
             yield line.rstrip('\n')
@@ -335,7 +349,7 @@ class BaseExtractor(object):
         for process in processes:
             process.stdout.close()
         self.check_success(False)
-    
+
 
 class CompressionExtractor(BaseExtractor):
     file_type = 'compressed file'
@@ -344,7 +358,7 @@ class CompressionExtractor(BaseExtractor):
     def basename(self):
         pieces = os.path.basename(self.filename).split('.')
         extension = '.' + pieces[-1]
-        if mimetypes.encodings_map.has_key(extension):
+        if extension in mimetypes.encodings_map:
             pieces.pop()
         return '.'.join(pieces)
 
@@ -368,7 +382,7 @@ class CompressionExtractor(BaseExtractor):
         self.included_root = './'
         try:
             output_fd, self.target = tempfile.mkstemp(prefix='.dtrx-', dir='.')
-        except (OSError, IOError), error:
+        except (OSError, IOError) as error:
             raise ExtractorError("cannot extract here: %s" % (error.strerror,))
         self.run_pipes(output_fd)
         os.close(output_fd)
@@ -378,13 +392,13 @@ class CompressionExtractor(BaseExtractor):
             os.unlink(self.target)
             raise
 
-            
+
 class TarExtractor(BaseExtractor):
     file_type = 'tar file'
     extract_pipe = ['tar', '-x']
     list_pipe = ['tar', '-t']
-        
-        
+
+
 class CpioExtractor(BaseExtractor):
     file_type = 'cpio file'
     extract_pipe = ['cpio', '-i', '--make-directories', '--quiet',
@@ -513,7 +527,7 @@ class ZipExtractor(NoPipeExtractor):
     list_command = ['zipinfo', '-1']
 
     def is_fatal_error(self, status):
-        return status > 1
+        return (status or 0) > 1
 
 
 class LZHExtractor(ZipExtractor):
@@ -563,7 +577,7 @@ class SevenExtractor(NoPipeExtractor):
             elif fn_index is not None:
                 yield line[fn_index:]
         self.archive.close()
-        
+
 
 class CABExtractor(NoPipeExtractor):
     file_type = 'CAB archive'
@@ -637,11 +651,11 @@ class UnarchiverExtractor(NoPipeExtractor):
 
     def get_filenames(self):
         output = NoPipeExtractor.get_filenames(self)
-        output.next()
+        next(output)
         for line in output:
             end_index = line.rfind('(')
             yield line[:end_index].strip()
-            
+
 
 class ArjExtractor(NoPipeExtractor):
     file_type = 'ARJ archive'
@@ -725,7 +739,7 @@ class OverwriteHandler(BaseHandler):
         if os.path.isdir(self.target):
             shutil.rmtree(self.target)
         os.rename(self.extractor.target, self.target)
-        
+
 
 class MatchHandler(BaseHandler):
     def can_handle(contents, options):
@@ -777,7 +791,8 @@ class BombHandler(BaseHandler):
         self.set_target(basename, self.extractor.name_checker)
         os.rename(self.extractor.target, self.target)
 
-        
+
+@total_ordering
 class BasePolicy(object):
     try:
         size = fcntl.ioctl(sys.stdout.fileno(), termios.TIOCGWINSZ,
@@ -789,7 +804,7 @@ class BasePolicy(object):
     choice_wrapper = textwrap.TextWrapper(width=width, initial_indent=' * ',
                                           subsequent_indent='   ',
                                           break_long_words=False)
-    
+
     def __init__(self, options):
         self.current_policy = None
         if options.batch:
@@ -802,15 +817,15 @@ class BasePolicy(object):
         for choice in self.choices:
             question.extend(self.choice_wrapper.wrap(choice))
         while True:
-            print "\n".join(question)
+            print("\n".join(question))
             try:
-                answer = raw_input(self.prompt)
+                answer = get_input(self.prompt)
             except EOFError:
                 return self.answers['']
             try:
                 return self.answers[answer.lower()]
             except KeyError:
-                print
+                print()
 
     def wrap(self, question, *args):
         words = question.split()
@@ -825,9 +840,12 @@ class BasePolicy(object):
                 result[-1] = extend
         return result
 
-    def __cmp__(self, other):
-        return cmp(self.current_policy, other)
-    
+    def __eq__(self, other):
+        return self.current_policy == other
+
+    def __lt__(self, other):
+        return self.current_policy < other
+
 
 class OneEntryPolicy(BasePolicy):
     answers = {'h': EXTRACT_HERE, 'i': EXTRACT_WRAP, 'r': EXTRACT_RENAME,
@@ -913,7 +931,7 @@ class RecursionPolicy(BasePolicy):
 
     def ok_to_recurse(self):
         return self.current_policy in (RECURSE_ALWAYS, RECURSE_ONCE)
-            
+
 
 class ExtractorBuilder(object):
     extractor_map = {'tar': {'extractors': (TarExtractor,),
@@ -1016,7 +1034,7 @@ class ExtractorBuilder(object):
 
     def build_extractor(self, archive_type, encoding):
         type_info = self.extractor_map[archive_type]
-        if self.options.metadata and type_info.has_key('metadata'):
+        if self.options.metadata and 'metadata' in type_info:
             extractors = type_info['metadata']
         else:
             extractors = type_info['extractors']
@@ -1058,14 +1076,14 @@ class ExtractorBuilder(object):
         return [result for regexp, result in magic_map.items()
                 if regexp.search(output)]
     magic_map_matches = classmethod(magic_map_matches)
-        
+
     def try_by_magic(cls, filename):
         process = subprocess.Popen(['file', '-zL', filename],
                                    stdout=subprocess.PIPE)
         status = process.wait()
         if status != 0:
             return []
-        output = process.stdout.readline()
+        output = process.stdout.readline().decode("ascii")
         process.stdout.close()
         if output.startswith('%s: ' % filename):
             output = output[len(filename) + 2:]
@@ -1094,11 +1112,11 @@ class BaseAction(object):
         self.filenames = filenames
         self.target = None
         self.do_print = False
-        
+
     def report(self, function, *args):
         try:
             error = function(*args)
-        except EXTRACTION_ERRORS, exception:
+        except EXTRACTION_ERRORS as exception:
             error = str(exception)
             logger.debug(''.join(traceback.format_exception(*sys.exc_info())))
         return error
@@ -1107,10 +1125,10 @@ class BaseAction(object):
         if len(self.filenames) < 2:
             return
         elif self.do_print:
-            print
+            print()
         else:
             self.do_print = True
-        print "%s:" % (filename,)
+        print("%s:" % (filename,))
 
 
 class ExtractionAction(BaseAction):
@@ -1132,13 +1150,13 @@ class ExtractionAction(BaseAction):
             return
         self.show_filename(self.current_filename)
         if extractor.contents is None:
-            print self.current_handler.target
+            print(self.current_handler.target)
             return
         def reverser(x, y):
             return cmp(y, x)
         if self.current_handler.target == '.':
             filenames = extractor.contents
-            filenames.sort(reverser)
+            filenames = sorted(filenames, key=cmp_to_key(reverser))
         else:
             filenames = [self.current_handler.target]
         pathjoin = os.path.join
@@ -1146,13 +1164,13 @@ class ExtractionAction(BaseAction):
         while filenames:
             filename = filenames.pop()
             if isdir(filename):
-                print "%s/" % (filename,)
+                print("%s/" % (filename,))
                 new_filenames = os.listdir(filename)
-                new_filenames.sort(reverser)
+                new_filenames = sorted(new_filenames, key=cmp_to_key(reverser))
                 filenames.extend([pathjoin(filename, new_filename)
                                   for new_filename in new_filenames])
             else:
-                print filename
+                print(filename)
 
     def run(self, filename, extractor):
         self.current_filename = filename
@@ -1171,16 +1189,16 @@ class ListAction(BaseAction):
         # basic error before we show what filename we're listing.
         filename_lister = extractor.get_filenames()
         try:
-            first_line = filename_lister.next()
+            first_line = next(filename_lister)
         except StopIteration:
             self.show_filename(filename)
         else:
             self.did_list = True
             self.show_filename(filename)
-            print first_line
+            print(first_line)
         for line in filename_lister:
-            print line
-            
+            print(line)
+
     def run(self, filename, extractor):
         self.did_list = False
         error = self.report(self.list_filenames, extractor, filename)
@@ -1203,13 +1221,13 @@ class ExtractorApplication(object):
     def clean_destination(self, dest_name):
         try:
             os.unlink(dest_name)
-        except OSError, error:
+        except OSError as error:
             if error.errno == errno.EISDIR:
                 shutil.rmtree(dest_name, ignore_errors=True)
 
     def abort(self, signal_num, frame):
         signal.signal(signal_num, signal.SIG_IGN)
-        print
+        print()
         logger.debug("traceback:\n" +
                      ''.join(traceback.format_stack(frame)).rstrip())
         logger.debug("got signal %s" % (signal_num,))
@@ -1302,7 +1320,7 @@ class ExtractorApplication(object):
     def check_file(self, filename):
         try:
             result = os.stat(filename)
-        except OSError, error:
+        except OSError as error:
             return error.strerror
         if stat.S_ISDIR(result.st_mode):
             return "cannot work with a directory"
@@ -1310,7 +1328,7 @@ class ExtractorApplication(object):
     def show_stderr(self, logger_func, stderr):
         if stderr:
             logger_func("Error output from this process:\n" +
-                        stderr.rstrip('\n'))
+                        stderr.rstrip(b'\n').decode("ascii", "ignore"))
 
     def try_extractors(self, filename, builder):
         errors = []
@@ -1337,7 +1355,7 @@ class ExtractorApplication(object):
             logger.error(' '.join(message))
             self.show_stderr(logger.error, stderr)
         return True
-        
+
     def download(self, filename):
         url = filename.lower()
         for protocol in 'http', 'https', 'ftp':
@@ -1358,7 +1376,7 @@ class ExtractorApplication(object):
             action = ListAction
         else:
             action = ExtractionAction
-        self.action = action(self.options, self.archives.values()[0])
+        self.action = action(self.options, list(self.archives.keys())[0])
         while self.archives:
             self.current_directory, self.filenames = self.archives.popitem()
             os.chdir(self.current_directory)

--- a/setup.py
+++ b/setup.py
@@ -1,26 +1,32 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
-setup(name="dtrx",
-      version = "7.1",
-      description = "Script to intelligently extract multiple archive types",
-      author = "Brett Smith",
-      author_email = "brettcsmith@brettcsmith.org",
-      url = "http://www.brettcsmith.org/2007/dtrx/",
-      download_url = "http://www.brettcsmith.org/2007/dtrx/",
-      scripts = ['scripts/dtrx'],
-      license = "GNU General Public License, version 3 or later",
-      classifiers = ['Development Status :: 5 - Production/Stable',
-                     'Environment :: Console',
-                     'Intended Audience :: End Users/Desktop',
-                     'Intended Audience :: System Administrators',
-                     'License :: OSI Approved :: GNU General Public License (GPL)',
-                     'Natural Language :: English',
-                     'Operating System :: POSIX',
-                     'Programming Language :: Python',
-                     'Topic :: Utilities'],
-      long_description = """dtrx extracts archives in a number of different
+setup(
+    name="dtrx",
+    version="7.2.0",
+    description="Script to intelligently extract multiple archive types",
+    author="Brett Smith",
+    author_email="brettcsmith@brettcsmith.org",
+    url="http://www.brettcsmith.org/2007/dtrx/",
+    project_urls={"Code": "https://github.com/brettcs/dtrx",},
+    download_url="https://github.com/brettcs/dtrx",
+    scripts=["scripts/dtrx"],
+    license="GNU General Public License, version 3 or later",
+    classifiers=[
+        "Development Status :: 5 - Production/Stable",
+        "Environment :: Console",
+        "Intended Audience :: End Users/Desktop",
+        "Intended Audience :: System Administrators",
+        "License :: OSI Approved :: GNU General Public License (GPL)",
+        "Natural Language :: English",
+        "Operating System :: POSIX",
+        "Programming Language :: Python",
+        "Topic :: Utilities",
+        "Programming Language :: Python :: 2.7",
+        "Programming Language :: Python :: 3.8",
+    ],
+    long_description="""dtrx extracts archives in a number of different
       formats; it currently supports tar, zip (including self-extracting
       .exe files), cpio, rpm, deb, gem, 7z, cab, rar, lzh, arj, and
       InstallShield files.  It can also decompress files compressed with gzip,
@@ -31,5 +37,14 @@ setup(name="dtrx",
       By default, everything will be written to a dedicated directory
       that's named after the archive.  dtrx will also change the
       permissions to ensure that the owner can read and write all those
-      files."""
-      )
+      files.""",
+    # Enable the below to swap the pypi description to the readme file. Also load readme above with:
+    # # Get long description from readme
+    # with io.open("README.md", "rt", encoding="utf8") as readmefile:
+    #     README = readmefile.read()
+    #     long_description=README,
+    #     long_description_content_type="text/markdown",
+    # using markdown as pypi description:
+    # https://dustingram.com/articles/2018/03/16/markdown-descriptions-on-pypi
+    setup_requires=["setuptools>=38.6.0", "wheel>=0.31.0", "twine>=1.11.0"],
+)

--- a/tests/tests.yml
+++ b/tests/tests.yml
@@ -109,7 +109,7 @@
     mkdir test-1.23
     cd test-1.23
     ar p ../$1 control.tar.gz | tar -zx
-    
+
 - name: .gem metadata
   filenames: test-1.23.gem
   options: -m
@@ -215,7 +215,7 @@
     cd test-1.23
     tar -jxf ../$1
   prerun: |
-    mkdir test-1.23 
+    mkdir test-1.23
 
 - name: flat option
   directory: inside-dir
@@ -284,6 +284,7 @@
   options: -n -l
   filenames: test-1.23.tar
   output: |
+    test-1.23.tar:
     test-1.23/
     test-1.23/1/
     test-1.23/1/2/
@@ -296,6 +297,7 @@
   options: -n -l
   filenames: test-1.23.lzh
   output: |
+    test-1.23.lzh:
     1/
     1/2/
     1/2/3
@@ -307,6 +309,7 @@
   options: -n -l
   filenames: test-1.23.arj
   output: |
+    test-1.23.arj:
     a/b
     1/2/3
     foobar
@@ -328,7 +331,7 @@
     a/
     a/b
     foobar
-    
+
     test-1.23.zip:
     1/2/3
     a/b
@@ -337,7 +340,9 @@
 - name: list contents of compressed file
   options: -n -t
   filenames: test-text.gz
-  output: test-text
+  output: |
+    test-text.gz:
+    test-text
 
 - name: default behavior with one directory (gz)
   options: -n
@@ -631,7 +636,7 @@
     1/2/3
     a/b
     foobar
-    
+
     trickery.tar.gz:
     1/2/3
     a/b
@@ -722,7 +727,7 @@
     test-onedir/test/
     test-onedir/test/foobar
     test-onedir/test/quux
-    
+
     test-text.gz:
     test-text
 
@@ -731,6 +736,7 @@
   directory: busydir
   filenames: ../test-onedir.tar.gz
   output: |
+    ../test-onedir.tar.gz:
     test/
     test/foobar
     test/quux
@@ -780,15 +786,16 @@
 - name: listing empty archive
   filenames: test-empty.tar.bz2
   options: -l
-  antigrep: '.'
+  baseline: |
+    test-empty.tar.bz2:
 
 - name: download and extract
-  filenames: http://brettcsmith.org/2007/dtrx/test-download.gz
+  filenames: https://raw.githubusercontent.com/brettcs/dtrx/master/tests/test-text.gz
   directory: inside-dir
   baseline: |
     wget "$1"
-    zcat test-download.gz >test-download
-  cleanup: rm -f test-download.gz test-download
+    zcat test-text.gz >test-text
+  cleanup: rm -f test-text.gz test-text
 
 - name: recursive archive without prompt
   filenames: test-recursive-no-prompt.tar.bz2

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,24 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[build-system]
+requires = [ "setuptools == 40.6.3", "wheel == 0.32.3"]
+
+[tox]
+envlist = py27, py36, py37, py38
+
+[testenv]
+whitelist_externals =
+    /bin/bash
+deps =
+    pyyaml==3.13
+setenv =
+    TOX_INI_DIR = {toxinidir}
+commands =
+    # sanity check
+    dtrx --help
+
+    # run tests
+    {envpython} tests/compare.py


### PR DESCRIPTION
Thank you for making this software, and making the source available!

This patch has a collection of modifications:

- update to be compatible with python 3.8
- update the tests to include the file list header
- update setup.py (version number bump and add python2.7 + python3.8
classifiers)
- add a dockerfile to preserve the testing environment, using tox as the
test runner
- converted the README to Markdown and added the extension so Github
renders it
- update .gitignore for the tox temporary files

The motivation for this patch-

Ubuntu 20.04 no longer has dtrx in the PPA's, I think because it only
supported python 2. I checked the pypi.org page for dtrx, but I think it
was migrated from pypi.python.org, and the package page is empty.

This patch should be enough to deploy an update to pypi.org, to make the
tool available to anyone via `pip install dtrx`. I've updated the readme
with that information too (and it may be worth adding a badge).

I've deployed a test version of this path to
https://pypi.org/project/dtrx-noahp/